### PR TITLE
pulse: Deal with header consitification in PulseAudio 13.0

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -828,7 +828,7 @@ pa_operation* pa_context_subscribe(pa_context *c, pa_subscription_mask_t m, pa_c
 }
 
 SPA_EXPORT
-pa_context *pa_context_new_with_proplist(pa_mainloop_api *mainloop, const char *name, pa_proplist *p)
+pa_context *pa_context_new_with_proplist(pa_mainloop_api *mainloop, const char *name, PA_CONST pa_proplist *p)
 {
 	struct pw_core *core;
 	struct pw_loop *loop;
@@ -944,7 +944,7 @@ void pa_context_set_event_callback(pa_context *c, pa_context_event_cb_t cb, void
 }
 
 SPA_EXPORT
-int pa_context_errno(pa_context *c)
+int pa_context_errno(PA_CONST pa_context *c)
 {
 	if (!c)
 		return PA_ERR_INVALID;
@@ -955,7 +955,7 @@ int pa_context_errno(pa_context *c)
 }
 
 SPA_EXPORT
-int pa_context_is_pending(pa_context *c)
+int pa_context_is_pending(PA_CONST pa_context *c)
 {
 	pa_assert(c);
 	pa_assert(c->refcount >= 1);
@@ -966,7 +966,7 @@ int pa_context_is_pending(pa_context *c)
 }
 
 SPA_EXPORT
-pa_context_state_t pa_context_get_state(pa_context *c)
+pa_context_state_t pa_context_get_state(PA_CONST pa_context *c)
 {
 	pa_assert(c);
 	pa_assert(c->refcount >= 1);
@@ -1090,7 +1090,7 @@ pa_operation* pa_context_set_default_source(pa_context *c, const char *name, pa_
 }
 
 SPA_EXPORT
-int pa_context_is_local(pa_context *c)
+int pa_context_is_local(PA_CONST pa_context *c)
 {
 	pa_assert(c);
 	pa_assert(c->refcount >= 1);
@@ -1128,7 +1128,7 @@ pa_operation* pa_context_set_name(pa_context *c, const char *name, pa_context_su
 }
 
 SPA_EXPORT
-const char* pa_context_get_server(pa_context *c)
+const char* pa_context_get_server(PA_CONST pa_context *c)
 {
 	const struct pw_core_info *info;
 
@@ -1142,13 +1142,13 @@ const char* pa_context_get_server(pa_context *c)
 }
 
 SPA_EXPORT
-uint32_t pa_context_get_protocol_version(pa_context *c)
+uint32_t pa_context_get_protocol_version(PA_CONST pa_context *c)
 {
 	return PA_PROTOCOL_VERSION;
 }
 
 SPA_EXPORT
-uint32_t pa_context_get_server_protocol_version(pa_context *c)
+uint32_t pa_context_get_server_protocol_version(PA_CONST pa_context *c)
 {
 	pa_assert(c);
 	pa_assert(c->refcount >= 1);
@@ -1159,7 +1159,7 @@ uint32_t pa_context_get_server_protocol_version(pa_context *c)
 }
 
 SPA_EXPORT
-pa_operation *pa_context_proplist_update(pa_context *c, pa_update_mode_t mode, pa_proplist *p, pa_context_success_cb_t cb, void *userdata)
+pa_operation *pa_context_proplist_update(pa_context *c, pa_update_mode_t mode, PA_CONST pa_proplist *p, pa_context_success_cb_t cb, void *userdata)
 {
 	pa_operation *o;
 	struct success_data *d;
@@ -1204,13 +1204,13 @@ pa_operation *pa_context_proplist_remove(pa_context *c, const char *const keys[]
 }
 
 SPA_EXPORT
-uint32_t pa_context_get_index(pa_context *c)
+uint32_t pa_context_get_index(PA_CONST pa_context *c)
 {
 	return c->client_index;
 }
 
 SPA_EXPORT
-pa_time_event* pa_context_rttime_new(pa_context *c, pa_usec_t usec, pa_time_event_cb_t cb, void *userdata)
+pa_time_event* pa_context_rttime_new(PA_CONST pa_context *c, pa_usec_t usec, pa_time_event_cb_t cb, void *userdata)
 {
 	struct timeval tv;
 
@@ -1227,7 +1227,7 @@ pa_time_event* pa_context_rttime_new(pa_context *c, pa_usec_t usec, pa_time_even
 }
 
 SPA_EXPORT
-void pa_context_rttime_restart(pa_context *c, pa_time_event *e, pa_usec_t usec)
+void pa_context_rttime_restart(PA_CONST pa_context *c, pa_time_event *e, pa_usec_t usec)
 {
 	struct timeval tv;
 
@@ -1244,7 +1244,7 @@ void pa_context_rttime_restart(pa_context *c, pa_time_event *e, pa_usec_t usec)
 }
 
 SPA_EXPORT
-size_t pa_context_get_tile_size(pa_context *c, const pa_sample_spec *ss)
+size_t pa_context_get_tile_size(PA_CONST pa_context *c, const pa_sample_spec *ss)
 {
 	size_t fs, mbs;
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -31,11 +31,19 @@
 #include <pulse/format.h>
 #include <pulse/subscribe.h>
 #include <pulse/introspect.h>
+#include <pulse/version.h>
 
 #include <pipewire/array.h>
 #include <pipewire/utils.h>
 #include <pipewire/interfaces.h>
 #include <pipewire/log.h>
+
+/* Some PulseAudio API added const qualifiers in 13.0 */
+#if PA_MAJOR >= 13
+#define PA_CONST const
+#else
+#define PA_CONST
+#endif
 
 #define PA_MAX_FORMATS (PA_ENCODING_MAX)
 

--- a/src/mainloop.c
+++ b/src/mainloop.c
@@ -310,7 +310,7 @@ int pa_mainloop_dispatch(pa_mainloop *m)
 }
 
 SPA_EXPORT
-int pa_mainloop_get_retval(pa_mainloop *m)
+int pa_mainloop_get_retval(PA_CONST pa_mainloop *m)
 {
 	return m->retval;
 }

--- a/src/operation.c
+++ b/src/operation.c
@@ -144,7 +144,7 @@ void pa_operation_done(pa_operation *o) {
 
 
 SPA_EXPORT
-pa_operation_state_t pa_operation_get_state(pa_operation *o)
+pa_operation_state_t pa_operation_get_state(PA_CONST pa_operation *o)
 {
 	pa_assert(o);
 	pa_assert(o->refcount >= 1);

--- a/src/proplist.c
+++ b/src/proplist.c
@@ -145,13 +145,13 @@ int pa_proplist_set(pa_proplist *p, const char *key, const void *data, size_t nb
 }
 
 SPA_EXPORT
-const char *pa_proplist_gets(pa_proplist *p, const char *key)
+const char *pa_proplist_gets(PA_CONST pa_proplist *p, const char *key)
 {
 	return pw_properties_get(p->props, key);
 }
 
 SPA_EXPORT
-int pa_proplist_get(pa_proplist *p, const char *key, const void **data, size_t *nbytes)
+int pa_proplist_get(PA_CONST pa_proplist *p, const char *key, const void **data, size_t *nbytes)
 {
 	const char *val;
 
@@ -223,7 +223,7 @@ int pa_proplist_unset_many(pa_proplist *p, const char * const keys[])
 }
 
 SPA_EXPORT
-const char *pa_proplist_iterate(pa_proplist *p, void **state)
+const char *pa_proplist_iterate(PA_CONST pa_proplist *p, void **state)
 {
 	spa_assert(p);
 	spa_assert(state);
@@ -231,14 +231,14 @@ const char *pa_proplist_iterate(pa_proplist *p, void **state)
 }
 
 SPA_EXPORT
-char *pa_proplist_to_string(pa_proplist *p)
+char *pa_proplist_to_string(PA_CONST pa_proplist *p)
 {
 	spa_assert(p);
 	return pa_proplist_to_string_sep(p, ",");
 }
 
 SPA_EXPORT
-char *pa_proplist_to_string_sep(pa_proplist *p, const char *sep)
+char *pa_proplist_to_string_sep(PA_CONST pa_proplist *p, const char *sep)
 {
 	const char *key;
 	void *state = NULL;
@@ -293,7 +293,7 @@ pa_proplist *pa_proplist_from_string(const char *str)
 }
 
 SPA_EXPORT
-int pa_proplist_contains(pa_proplist *p, const char *key)
+int pa_proplist_contains(PA_CONST pa_proplist *p, const char *key)
 {
 	spa_assert(p);
 	spa_assert(key);
@@ -330,21 +330,21 @@ pa_proplist* pa_proplist_copy(const pa_proplist *p)
 }
 
 SPA_EXPORT
-unsigned pa_proplist_size(pa_proplist *p)
+unsigned pa_proplist_size(PA_CONST pa_proplist *p)
 {
 	spa_assert(p);
 	return p->props->dict.n_items;
 }
 
 SPA_EXPORT
-int pa_proplist_isempty(pa_proplist *p)
+int pa_proplist_isempty(PA_CONST pa_proplist *p)
 {
 	spa_assert(p);
 	return p->props->dict.n_items == 0 ? 1 : 0;
 }
 
 SPA_EXPORT
-int pa_proplist_equal(pa_proplist *a, pa_proplist *b)
+int pa_proplist_equal(PA_CONST pa_proplist *a, PA_CONST pa_proplist *b)
 {
 	uint32_t i;
 

--- a/src/scache.c
+++ b/src/scache.c
@@ -54,7 +54,7 @@ pa_operation* pa_context_play_sample(pa_context *c, const char *name, const char
 
 SPA_EXPORT
 pa_operation* pa_context_play_sample_with_proplist(pa_context *c, const char *name,
-        const char *dev, pa_volume_t volume, pa_proplist *proplist,
+        const char *dev, pa_volume_t volume, PA_CONST pa_proplist *proplist,
         pa_context_play_sample_cb_t cb, void *userdata)
 {
 	pw_log_warn("Not Implemented");

--- a/src/stream.c
+++ b/src/stream.c
@@ -722,7 +722,7 @@ pa_stream *pa_stream_ref(pa_stream *s)
 }
 
 SPA_EXPORT
-pa_stream_state_t pa_stream_get_state(pa_stream *s)
+pa_stream_state_t pa_stream_get_state(PA_CONST pa_stream *s)
 {
 	spa_assert(s);
 	spa_assert(s->refcount >= 1);
@@ -730,7 +730,7 @@ pa_stream_state_t pa_stream_get_state(pa_stream *s)
 }
 
 SPA_EXPORT
-pa_context* pa_stream_get_context(pa_stream *s)
+pa_context* pa_stream_get_context(PA_CONST pa_stream *s)
 {
 	spa_assert(s);
 	spa_assert(s->refcount >= 1);
@@ -738,7 +738,7 @@ pa_context* pa_stream_get_context(pa_stream *s)
 }
 
 SPA_EXPORT
-uint32_t pa_stream_get_index(pa_stream *s)
+uint32_t pa_stream_get_index(PA_CONST pa_stream *s)
 {
 	uint32_t idx;
 
@@ -773,7 +773,7 @@ void pa_stream_set_state(pa_stream *s, pa_stream_state_t st) {
 
 
 SPA_EXPORT
-uint32_t pa_stream_get_device_index(pa_stream *s)
+uint32_t pa_stream_get_device_index(PA_CONST pa_stream *s)
 {
 	spa_assert(s);
 	spa_assert(s->refcount >= 1);
@@ -790,7 +790,7 @@ uint32_t pa_stream_get_device_index(pa_stream *s)
 }
 
 SPA_EXPORT
-const char *pa_stream_get_device_name(pa_stream *s)
+const char *pa_stream_get_device_name(PA_CONST pa_stream *s)
 {
 	spa_assert(s);
 	spa_assert(s->refcount >= 1);
@@ -806,7 +806,7 @@ const char *pa_stream_get_device_name(pa_stream *s)
 }
 
 SPA_EXPORT
-int pa_stream_is_suspended(pa_stream *s)
+int pa_stream_is_suspended(PA_CONST pa_stream *s)
 {
 	spa_assert(s);
 	spa_assert(s->refcount >= 1);
@@ -818,7 +818,7 @@ int pa_stream_is_suspended(pa_stream *s)
 }
 
 SPA_EXPORT
-int pa_stream_is_corked(pa_stream *s)
+int pa_stream_is_corked(PA_CONST pa_stream *s)
 {
 	spa_assert(s);
 	spa_assert(s->refcount >= 1);
@@ -1274,7 +1274,7 @@ int pa_stream_drop(pa_stream *s)
 }
 
 SPA_EXPORT
-size_t pa_stream_writable_size(pa_stream *s)
+size_t pa_stream_writable_size(PA_CONST pa_stream *s)
 {
 	spa_assert(s);
 	spa_assert(s->refcount >= 1);
@@ -1289,7 +1289,7 @@ size_t pa_stream_writable_size(pa_stream *s)
 }
 
 SPA_EXPORT
-size_t pa_stream_readable_size(pa_stream *s)
+size_t pa_stream_readable_size(PA_CONST pa_stream *s)
 {
 	spa_assert(s);
 	spa_assert(s->refcount >= 1);
@@ -1427,7 +1427,7 @@ void pa_stream_set_overflow_callback(pa_stream *s, pa_stream_notify_cb_t cb, voi
 }
 
 SPA_EXPORT
-int64_t pa_stream_get_underflow_index(pa_stream *s)
+int64_t pa_stream_get_underflow_index(PA_CONST pa_stream *s)
 {
 	pw_log_warn("Not Implemented");
 	return 0;
@@ -1767,7 +1767,7 @@ const pa_channel_map* pa_stream_get_channel_map(pa_stream *s)
 }
 
 SPA_EXPORT
-const pa_format_info* pa_stream_get_format_info(pa_stream *s)
+const pa_format_info* pa_stream_get_format_info(PA_CONST pa_stream *s)
 {
 	spa_assert(s);
 	spa_assert(s->refcount >= 1);
@@ -1896,7 +1896,7 @@ int pa_stream_set_monitor_stream(pa_stream *s, uint32_t sink_input_idx)
 }
 
 SPA_EXPORT
-uint32_t pa_stream_get_monitor_stream(pa_stream *s)
+uint32_t pa_stream_get_monitor_stream(PA_CONST pa_stream *s)
 {
 	spa_assert(s);
 	spa_assert(s->refcount >= 1);

--- a/src/thread-mainloop.c
+++ b/src/thread-mainloop.c
@@ -108,7 +108,7 @@ void pa_threaded_mainloop_accept(pa_threaded_mainloop *m)
 }
 
 SPA_EXPORT
-int pa_threaded_mainloop_get_retval(pa_threaded_mainloop *m)
+int pa_threaded_mainloop_get_retval(PA_CONST pa_threaded_mainloop *m)
 {
 	return pa_mainloop_get_retval(m->loop);
 }

--- a/src/volume.c
+++ b/src/volume.c
@@ -953,7 +953,7 @@ pa_cvolume* pa_cvolume_set_position(
 
 SPA_EXPORT
 pa_volume_t pa_cvolume_get_position(
-        pa_cvolume *cv,
+        PA_CONST pa_cvolume *cv,
         const pa_channel_map *map,
         pa_channel_position_t t) {
 


### PR DESCRIPTION
The 13.0 release included changes to constify various parameters in the
public headers, which breaks our implementation. This adds an optional
const qualifier based on the version we're compiling against to deal
with that. There are some warnings caused by bad annotations upstream
which should be fixed separately.